### PR TITLE
Fix warning from compilers where sizeof(size_t) > sizeof(int)

### DIFF
--- a/radix_tree.hpp
+++ b/radix_tree.hpp
@@ -34,7 +34,7 @@ int radix_length(const K &key);
 template<>
 inline int radix_length<std::string>(const std::string &key)
 {
-    return key.size();
+    return static_cast<int>(key.size());
 }
 
 template <typename K, typename T, typename Compare>


### PR DESCRIPTION
Without this fix, a bunch of warnings are spewed

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>