### PR TITLE
Replace raw pointers in STL containers with unique_ptr

### DIFF
--- a/radix_tree_it.hpp
+++ b/radix_tree_it.hpp
@@ -49,7 +49,7 @@ radix_tree_node<K, T, Compare>* radix_tree_it<K, T, Compare>::increment(radix_tr
     if (it == parent->m_children.end())
         return increment(parent);
     else
-        return descend(it->second);
+        return descend(it->second.get());
 }
 
 template <typename K, typename T, typename Compare>
@@ -62,19 +62,19 @@ radix_tree_node<K, T, Compare>* radix_tree_it<K, T, Compare>::descend(radix_tree
 
     assert(it != node->m_children.end());
 
-    return descend(it->second);
+    return descend(it->second.get());
 }
 
 template <typename K, typename T, typename Compare>
 std::pair<const K, T>& radix_tree_it<K, T, Compare>::operator* () const
 {
-    return *m_pointee->m_value;
+    return *m_pointee->m_value.get();
 }
 
 template <typename K, typename T, typename Compare>
 std::pair<const K, T>* radix_tree_it<K, T, Compare>::operator-> () const
 {
-    return m_pointee->m_value;
+    return m_pointee->m_value.get();
 }
 
 template <typename K, typename T, typename Compare>

--- a/radix_tree_node.hpp
+++ b/radix_tree_node.hpp
@@ -1,8 +1,9 @@
 #ifndef RADIX_TREE_NODE_HPP
 #define RADIX_TREE_NODE_HPP
 
-#include <map>
 #include <functional>
+#include <map>
+#include <memory>
 
 template <typename K, typename T, typename Compare>
 class radix_tree_node {
@@ -10,19 +11,27 @@ class radix_tree_node {
     friend class radix_tree_it<K, T, Compare>;
 
     typedef std::pair<const K, T> value_type;
-    typedef typename std::map<K, radix_tree_node<K, T, Compare>*, Compare >::iterator it_child;
+    typedef typename std::map<K, std::unique_ptr<radix_tree_node<K, T, Compare>>, Compare >::iterator it_child;
 
-private:
-	radix_tree_node(Compare& pred) : m_children(std::map<K, radix_tree_node<K, T, Compare>*, Compare>(pred)), m_parent(NULL), m_value(NULL), m_depth(0), m_is_leaf(false), m_key(), m_pred(pred) { }
+public:
+	radix_tree_node(Compare& pred) : m_children(std::map<K, std::unique_ptr<radix_tree_node<K, T, Compare>>, Compare>(pred)), m_parent(NULL), m_depth(0), m_is_leaf(false), m_key(), m_pred(pred) { }
     radix_tree_node(const value_type &val, Compare& pred);
     radix_tree_node(const radix_tree_node&); // delete
     radix_tree_node& operator=(const radix_tree_node&); // delete
 
     ~radix_tree_node();
 
-    std::map<K, radix_tree_node<K, T, Compare>*, Compare> m_children;
+  private:
+    std::unique_ptr<radix_tree_node<K, T, Compare>>&& remove_child(const K &key);
+
+    // This class owns instances of radix_tree_node stored in m_children.
+    std::map<K, std::unique_ptr<radix_tree_node<K, T, Compare>>, Compare> m_children;
+    
+    // This class does not own instances of radix_tree_node stored in m_parent.
     radix_tree_node<K, T, Compare> *m_parent;
-    value_type *m_value;
+    
+    // This class owns instances of value_type stored in m_value.
+    std::unique_ptr<value_type> m_value;
     int m_depth;
     bool m_is_leaf;
     K m_key;
@@ -31,26 +40,20 @@ private:
 
 template <typename K, typename T, typename Compare>
 radix_tree_node<K, T, Compare>::radix_tree_node(const value_type &val, Compare& pred) :
-    m_children(std::map<K, radix_tree_node<K, T, Compare>*, Compare>(pred)),
+    m_children(std::map<K, std::unique_ptr<radix_tree_node<K, T, Compare>>, Compare>(pred)),
     m_parent(NULL),
-    m_value(NULL),
     m_depth(0),
     m_is_leaf(false),
     m_key(), 
 	m_pred(pred)
 {
-    m_value = new value_type(val);
+    m_value = std::make_unique<value_type>(val);
 }
 
 template <typename K, typename T, typename Compare>
 radix_tree_node<K, T, Compare>::~radix_tree_node()
 {
-    it_child it;
-    for (it = m_children.begin(); it != m_children.end(); ++it) {
-        delete it->second;
-    }
-    delete m_value;
+    m_value.reset();
 }
-
 
 #endif // RADIX_TREE_NODE_HPP


### PR DESCRIPTION
Resolves: #24 

Design:
Replace non-owning references in STL containers with owning references (std::unique_ptr).
Non-owning references remain as raw pointers.
 
Alternative design considered but rejected:
Replace all references with std::shared_ptr. The issue is that this runs the risk of creating circular reference chains. 

Signed-off-by: Alan Jowett <Alan.Jowett@microsoft.com>