### PR TITLE
Revert "Replace raw pointers in STL containers with unique_ptr"

### DIFF
--- a/radix_tree_it.hpp
+++ b/radix_tree_it.hpp
@@ -49,7 +49,7 @@ radix_tree_node<K, T, Compare>* radix_tree_it<K, T, Compare>::increment(radix_tr
     if (it == parent->m_children.end())
         return increment(parent);
     else
-        return descend(it->second.get());
+        return descend(it->second);
 }
 
 template <typename K, typename T, typename Compare>
@@ -62,19 +62,19 @@ radix_tree_node<K, T, Compare>* radix_tree_it<K, T, Compare>::descend(radix_tree
 
     assert(it != node->m_children.end());
 
-    return descend(it->second.get());
+    return descend(it->second);
 }
 
 template <typename K, typename T, typename Compare>
 std::pair<const K, T>& radix_tree_it<K, T, Compare>::operator* () const
 {
-    return *m_pointee->m_value.get();
+    return *m_pointee->m_value;
 }
 
 template <typename K, typename T, typename Compare>
 std::pair<const K, T>* radix_tree_it<K, T, Compare>::operator-> () const
 {
-    return m_pointee->m_value.get();
+    return m_pointee->m_value;
 }
 
 template <typename K, typename T, typename Compare>

--- a/radix_tree_node.hpp
+++ b/radix_tree_node.hpp
@@ -1,9 +1,8 @@
 #ifndef RADIX_TREE_NODE_HPP
 #define RADIX_TREE_NODE_HPP
 
-#include <functional>
 #include <map>
-#include <memory>
+#include <functional>
 
 template <typename K, typename T, typename Compare>
 class radix_tree_node {
@@ -11,27 +10,19 @@ class radix_tree_node {
     friend class radix_tree_it<K, T, Compare>;
 
     typedef std::pair<const K, T> value_type;
-    typedef typename std::map<K, std::unique_ptr<radix_tree_node<K, T, Compare>>, Compare >::iterator it_child;
+    typedef typename std::map<K, radix_tree_node<K, T, Compare>*, Compare >::iterator it_child;
 
-public:
-	radix_tree_node(Compare& pred) : m_children(std::map<K, std::unique_ptr<radix_tree_node<K, T, Compare>>, Compare>(pred)), m_parent(NULL), m_depth(0), m_is_leaf(false), m_key(), m_pred(pred) { }
+private:
+	radix_tree_node(Compare& pred) : m_children(std::map<K, radix_tree_node<K, T, Compare>*, Compare>(pred)), m_parent(NULL), m_value(NULL), m_depth(0), m_is_leaf(false), m_key(), m_pred(pred) { }
     radix_tree_node(const value_type &val, Compare& pred);
     radix_tree_node(const radix_tree_node&); // delete
     radix_tree_node& operator=(const radix_tree_node&); // delete
 
     ~radix_tree_node();
 
-  private:
-    std::unique_ptr<radix_tree_node<K, T, Compare>>&& remove_child(const K &key);
-
-    // This class owns instances of radix_tree_node stored in m_children.
-    std::map<K, std::unique_ptr<radix_tree_node<K, T, Compare>>, Compare> m_children;
-    
-    // This class does not own instances of radix_tree_node stored in m_parent.
+    std::map<K, radix_tree_node<K, T, Compare>*, Compare> m_children;
     radix_tree_node<K, T, Compare> *m_parent;
-    
-    // This class owns instances of value_type stored in m_value.
-    std::unique_ptr<value_type> m_value;
+    value_type *m_value;
     int m_depth;
     bool m_is_leaf;
     K m_key;
@@ -40,20 +31,26 @@ public:
 
 template <typename K, typename T, typename Compare>
 radix_tree_node<K, T, Compare>::radix_tree_node(const value_type &val, Compare& pred) :
-    m_children(std::map<K, std::unique_ptr<radix_tree_node<K, T, Compare>>, Compare>(pred)),
+    m_children(std::map<K, radix_tree_node<K, T, Compare>*, Compare>(pred)),
     m_parent(NULL),
+    m_value(NULL),
     m_depth(0),
     m_is_leaf(false),
     m_key(), 
 	m_pred(pred)
 {
-    m_value = std::make_unique<value_type>(val);
+    m_value = new value_type(val);
 }
 
 template <typename K, typename T, typename Compare>
 radix_tree_node<K, T, Compare>::~radix_tree_node()
 {
-    m_value.reset();
+    it_child it;
+    for (it = m_children.begin(); it != m_children.end(); ++it) {
+        delete it->second;
+    }
+    delete m_value;
 }
+
 
 #endif // RADIX_TREE_NODE_HPP


### PR DESCRIPTION
Reverts ytakano/radix_tree#25, because examples could not be compiled.

```text
$ cd examples
$ g++ example1.cpp
```
